### PR TITLE
Run development env behind nginx so hosts can be rewritten

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You can test your setup by starting the application:
 $ make up
 ```
 
-which should enable you to access the docs at <http://0.0.0.0:4000/>.
+which should enable you to access the docs at <http://localhost:4000/>.
 
 ### License
 

--- a/_config.yml
+++ b/_config.yml
@@ -31,6 +31,7 @@ exclude:
   - Makefile
   - output
   - build
+  - nginx.conf
 
 # Set a path/url to a logo that will be displayed instead of the title
 logo: https://offen.github.io/press-kit/offen-logo/offen-logo-black.svg

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,20 @@
 version: '3'
 
 services:
+  proxy:
+    image: nginx:1.17-alpine
+    ports:
+      - 4000:4000
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf
+    depends_on:
+      - docs
+
   docs:
     build:
       context: '.'
       dockerfile: ./Dockerfile.ruby
     working_dir: /repo
-    ports:
-      - 4000:4000
     volumes:
       - .:/repo
       - docsdeps:/usr/local/bundle

--- a/index.md
+++ b/index.md
@@ -14,15 +14,15 @@ Depending on who you are and what you want to do, we have a few guides for you:
 
 ## I run a website and would like to run Offen to collect usage statistics
 
-Have a look at our [guide to running Offen](./running-offen).
+Have a look at our [guide to running Offen](/running-offen/).
 
 ## I am a user or operator and would like to understand how to use Offen
 
-Have a look at our [guide to using Offen](./using-offen).
+Have a look at our [guide to using Offen](/using-offen/).
 
 ## I am a developer and would like to work on Offen
 
-Have a look at our [guide to developing Offen](./developing-offen).
+Have a look at our [guide to developing Offen](/developing-offen/).
 
 ---
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,17 @@
+events {}
+
+http {
+	upstream docs {
+		server docs:4000;
+	}
+	server {
+		listen 4000;
+		location / {
+			sub_filter_once off;
+			sub_filter_types text/html text/css application/javascript;
+			sub_filter http://0.0.0.0 http://localhost;
+			proxy_pass http://docs;
+			proxy_redirect off;
+		}
+	}
+}


### PR DESCRIPTION
The Jekyll theme we use hardcodes the Jekyll host into absolute links, which is unfortunate in combination with our local Docker setup as it ends up creating links pointing to `0.0.0.0` which is unexpected in local dev.

Instead we can have nginx in front of the setup and rewrite these links back to `localhost`.